### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,38 +3,29 @@
     "description": "Manages typescript dependencies.",
     "version": "0.1.2",
     "homepage": "https://github.com/jarends/grunt-marshal",
-    "author":
-    {
+    "author": {
         "name": "Jan-Olaf Arends",
         "email": "jan.arends@definitely.eu"
     },
-    "repository":
-    {
+    "repository": {
         "type": "git",
         "url": "git://github.com/jarends/grunt-marshal.git"
     },
-    "bugs":
-    {
+    "bugs": {
         "url": "https://github.com/jarends/grunt-marshal/issues"
     },
     "license": "MIT",
-    "engines":
-    {
+    "engines": {
         "node": ">= 0.8.0"
     },
-    "peerDependencies":
-    {
+    "peerDependencies": {
+        "grunt": ">=0.4.0"
+    },
+    "dependencies": {},
+    "devDependencies": {
         "grunt": "~0.4.5"
     },
-    "dependencies":
-    {
-    },
-    "devDependencies":
-    {
-        "grunt": "~0.4.5"
-    },
-    "keywords":
-    [
+    "keywords": [
         "gruntplugin"
     ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
